### PR TITLE
Fix file input configuration in form template

### DIFF
--- a/templates/form.html
+++ b/templates/form.html
@@ -13,7 +13,7 @@
   {% for label in labels %}
     <div>
       <label class="block mb-1">{{ label }}</label>
-      <input type="file" name="files" class="w-full border rounded" accept="{{ current_app.config['UPLOAD_EXTENSIONS']|join(',') }}">
+      <input type="file" name="files" class="w-full border rounded" accept="{{ config['UPLOAD_EXTENSIONS']|join(',') }}">
     </div>
   {% endfor %}
 


### PR DESCRIPTION
## Summary
- access Flask config directly in templates to list allowed file extensions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893678f89748322b6a82fe33f509cc2