### PR TITLE
Add configuration interfaces for mail and OneDrive

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -5,12 +5,13 @@ import json
 MENU_CONFIG = 'menu_config.csv'
 FILE_CONFIG = 'file_config.csv'
 FIELD_CONFIG = 'field_config.json'
+SETTINGS_FILE = 'settings.json'
 
 
 def init_configs():
     if not os.path.exists(MENU_CONFIG):
         with open(MENU_CONFIG, 'w', newline='', encoding='utf-8') as f:
-            csv.writer(f).writerow(['emisores', 'EMISORES', ''])
+            csv.writer(f).writerow(['emisores', 'EMISORES', '', 'Inscripciones'])
     if not os.path.exists(FILE_CONFIG):
         with open(FILE_CONFIG, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
@@ -35,13 +36,33 @@ def init_configs():
         }
         with open(FIELD_CONFIG, 'w', encoding='utf-8') as f:
             json.dump(default_fields, f, ensure_ascii=False, indent=2)
+    if not os.path.exists(SETTINGS_FILE):
+        default_settings = {
+            "mail": {"email": "", "password": "", "tested": False},
+            "onedrive": {
+                "client_id": "",
+                "client_secret": "",
+                "tenant_id": "",
+                "user_id": "",
+                "redirect_uri": "",
+                "tested": False,
+            },
+        }
+        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(default_settings, f, ensure_ascii=False, indent=2)
 
 
 def load_menu():
     items = []
     with open(MENU_CONFIG, newline='', encoding='utf-8') as f:
-        for key, name, parent in csv.reader(f):
-            items.append({'key': key, 'name': name, 'parent': parent})
+        for row in csv.reader(f):
+            if not row:
+                continue
+            key = row[0]
+            name = row[1] if len(row) > 1 else ''
+            parent = row[2] if len(row) > 2 else ''
+            base_path = row[3] if len(row) > 3 else ''
+            items.append({'key': key, 'name': name, 'parent': parent, 'base_path': base_path})
     return items
 
 
@@ -63,3 +84,25 @@ def load_text_fields(cat):
     with open(FIELD_CONFIG, encoding='utf-8') as f:
         data = json.load(f)
     return data.get(cat, [])
+
+
+def load_settings():
+    if not os.path.exists(SETTINGS_FILE):
+        init_configs()
+    with open(SETTINGS_FILE, encoding='utf-8') as f:
+        return json.load(f)
+
+
+def save_settings(data):
+    with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def is_setup_complete():
+    settings = load_settings()
+    mail = settings.get('mail', {})
+    drive = settings.get('onedrive', {})
+    mail_ok = all(mail.get(k) for k in ('email', 'password')) and mail.get('tested')
+    drive_ok = all(drive.get(k) for k in ('client_id', 'client_secret', 'tenant_id', 'user_id')) and drive.get('tested')
+    menu_ok = bool(load_menu())
+    return mail_ok and drive_ok and menu_ok

--- a/menu_config.csv
+++ b/menu_config.csv
@@ -1,1 +1,1 @@
-emisores,EMISORES,
+emisores,EMISORES,,Inscripciones

--- a/services/mail.py
+++ b/services/mail.py
@@ -1,30 +1,28 @@
-# services/mail.py
-import os
-import requests
-
-CLIENT_ID = os.getenv('CLIENT_ID')
-TENANT_ID = os.getenv('TENANT_ID')
-CLIENT_SECRET = os.getenv('CLIENT_SECRET')
-USER_ID = os.getenv('USER_ID')
-RECIPIENT = os.getenv('RECIPIENT_EMAIL', USER_ID)
+import smtplib
+from email.mime.text import MIMEText
+from app.utils import load_settings
 
 
-def get_access_token():
-    url = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
-    data = {
-        'client_id': CLIENT_ID,
-        'scope': 'https://graph.microsoft.com/.default',
-        'client_secret': CLIENT_SECRET,
-        'grant_type': 'client_credentials'
-    }
-    response = requests.post(url, data=data)
-    if response.status_code >= 400:
-        raise Exception(f"Error obteniendo token: {response.text}")
-    return response.json()['access_token']
+SMTP_HOST = 'smtp.gmail.com'
+SMTP_PORT = 587
+
+
+def test_connection(email: str, password: str) -> None:
+    if not email or not password:
+        raise ValueError('Credenciales incompletas')
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as server:
+        server.starttls()
+        server.login(email, password)
+        server.noop()
 
 
 def send_mail(nombre, categoria, fields, file_links):
-    token = get_access_token()
+    cfg = load_settings().get('mail', {})
+    email = cfg.get('email')
+    password = cfg.get('password')
+    if not email or not password:
+        raise ValueError('Correo no configurado')
+
     subject = f"Inscripción recibida: {nombre} - {categoria}"
     body = "<p>Se ha recibido una inscripción con los siguientes datos:</p><ul>"
     for label, value in fields.items():
@@ -34,22 +32,12 @@ def send_mail(nombre, categoria, fields, file_links):
         body += f"<li><a href='{link}'>{link}</a></li>"
     body += "</ul>"
 
-    message = {
-        "message": {
-            "subject": subject,
-            "body": {
-                "contentType": "HTML",
-                "content": body
-            },
-            "toRecipients": [
-                {"emailAddress": {"address": RECIPIENT}}
-            ]
-        }
-    }
+    msg = MIMEText(body, 'html')
+    msg['Subject'] = subject
+    msg['From'] = email
+    msg['To'] = email
 
-    url = f"https://graph.microsoft.com/v1.0/users/{USER_ID}/sendMail"
-    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
-    r = requests.post(url, headers=headers, json=message)
-    if r.status_code >= 300:
-        raise Exception(f"Error enviando correo: {r.text}")
-
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+        server.starttls()
+        server.login(email, password)
+        server.sendmail(email, [email], msg.as_string())

--- a/services/onedrive.py
+++ b/services/onedrive.py
@@ -1,66 +1,61 @@
-# services/onedrive.py
-import os
 import requests
 from werkzeug.utils import secure_filename
-
-CLIENT_ID = os.getenv("CLIENT_ID")
-TENANT_ID = os.getenv("TENANT_ID")
-CLIENT_SECRET = os.getenv("CLIENT_SECRET")
-USER_ID = os.getenv("USER_ID")
-CARPETA_BASE = os.getenv("CARPETA_BASE", "Inscripciones")
+from app.utils import load_settings
 
 
-def get_access_token():
-    url = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
+def get_access_token(cfg=None):
+    if cfg is None:
+        cfg = load_settings().get('onedrive', {})
+    url = f"https://login.microsoftonline.com/{cfg.get('tenant_id')}/oauth2/v2.0/token"
     data = {
-        "client_id": CLIENT_ID,
-        "scope": "https://graph.microsoft.com/.default",
-        "client_secret": CLIENT_SECRET,
-        "grant_type": "client_credentials",
+        'client_id': cfg.get('client_id'),
+        'scope': 'https://graph.microsoft.com/.default',
+        'client_secret': cfg.get('client_secret'),
+        'grant_type': 'client_credentials',
     }
     response = requests.post(url, data=data)
     if response.status_code >= 400:
         raise Exception(f"Error obteniendo token: {response.text}")
-    return response.json()["access_token"]
+    return response.json()['access_token']
 
 
-def create_folder_if_not_exists(token, folder_name, parent="root"):
-    headers = {"Authorization": f"Bearer {token}"}
-    base_url = f"https://graph.microsoft.com/v1.0/users/{USER_ID}/drive/{parent}/children"
+def test_connection(client_id, tenant_id, client_secret):
+    get_access_token({'client_id': client_id, 'tenant_id': tenant_id, 'client_secret': client_secret})
 
-    # Buscar si la carpeta ya existe
+
+def create_folder_if_not_exists(token, user_id, folder_name, parent='root'):
+    headers = {'Authorization': f'Bearer {token}'}
+    base_url = f"https://graph.microsoft.com/v1.0/users/{user_id}/drive/{parent}/children"
     search_url = base_url + f"?$filter=name eq '{folder_name}'"
     r = requests.get(search_url, headers=headers)
     if r.status_code >= 400:
         raise Exception(f"Error buscando carpeta: {r.text}")
-    items = r.json().get("value", [])
+    items = r.json().get('value', [])
     if items:
-        return items[0]["id"]
-
-    # Crear carpeta si no existe
-    headers["Content-Type"] = "application/json"
-    data = {"name": folder_name, "folder": {}, "@microsoft.graph.conflictBehavior": "rename"}
+        return items[0]['id']
+    headers['Content-Type'] = 'application/json'
+    data = {'name': folder_name, 'folder': {}, '@microsoft.graph.conflictBehavior': 'rename'}
     r = requests.post(base_url, headers=headers, json=data)
     if r.status_code >= 400:
         raise Exception(f"Error creando carpeta: {r.text}")
-    return r.json()["id"]
+    return r.json()['id']
 
 
-def upload_files(nombre, categoria, files):
-    token = get_access_token()
-    root_id = create_folder_if_not_exists(token, CARPETA_BASE)
-    cat_id = create_folder_if_not_exists(token, categoria, f"items/{root_id}")
-    user_id = create_folder_if_not_exists(token, nombre, f"items/{cat_id}")
-
+def upload_files(nombre, categoria, base_path, files):
+    cfg = load_settings()['onedrive']
+    user_id = cfg.get('user_id')
+    token = get_access_token(cfg)
+    root_id = create_folder_if_not_exists(token, user_id, base_path)
+    cat_id = create_folder_if_not_exists(token, user_id, categoria, f"items/{root_id}")
+    user_folder = create_folder_if_not_exists(token, user_id, nombre, f"items/{cat_id}")
     file_links = []
     for f in files:
         filename = secure_filename(f.filename)
         content = f.read()
-        upload_url = f"https://graph.microsoft.com/v1.0/users/{USER_ID}/drive/items/{user_id}:/{filename}:/content"
-        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/octet-stream"}
+        upload_url = f"https://graph.microsoft.com/v1.0/users/{user_id}/drive/items/{user_folder}:/{filename}:/content"
+        headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/octet-stream'}
         r = requests.put(upload_url, headers=headers, data=content)
         if r.status_code >= 400:
             raise Exception(f"Error subiendo archivo {filename}: {r.text}")
-        file_links.append(r.json()["webUrl"])
-
-    return f"{CARPETA_BASE}/{categoria}/{nombre}", file_links
+        file_links.append(r.json()['webUrl'])
+    return f"{base_path}/{categoria}/{nombre}", file_links

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,15 @@
+{
+  "mail": {
+    "email": "",
+    "password": "",
+    "tested": false
+  },
+  "onedrive": {
+    "client_id": "",
+    "client_secret": "",
+    "tenant_id": "",
+    "user_id": "",
+    "redirect_uri": "",
+    "tested": false
+  }
+}

--- a/templates/admin_fields.html
+++ b/templates/admin_fields.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Admin Campos{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Campos de texto por Categoría</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block mb-1">Categoría</label>
+    <select name="category" class="border rounded w-full p-2">
+      {% for item in menu %}
+        <option value="{{ item.key }}">{{ item.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Campos (JSON)</label>
+    <textarea name="fields" rows="6" class="border rounded w-full p-2">{{ fields|tojson(indent=2) }}</textarea>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+</form>
+{% endblock %}

--- a/templates/admin_menu.html
+++ b/templates/admin_menu.html
@@ -15,12 +15,16 @@
     <label class="block mb-1">Padre (vacío si es raíz)</label>
     <input name="parent" class="border rounded w-full p-2">
   </div>
+  <div>
+    <label class="block mb-1">Ruta base OneDrive</label>
+    <input name="base_path" class="border rounded w-full p-2">
+  </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Agregar</button>
 </form>
 <h2 class="text-xl font-semibold mt-8 mb-2">Categorías existentes</h2>
 <ul class="list-disc pl-5">
   {% for item in menu %}
-    <li>{{ item.name }} (clave: {{ item.key }}, padre: {{ item.parent }})</li>
+    <li>{{ item.name }} (clave: {{ item.key }}, padre: {{ item.parent }}, ruta: {{ item.base_path }})</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block title %}Configuración{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Configuración del sistema</h1>
+<form method="post" class="space-y-4">
+  <h2 class="text-xl font-semibold">Correo remitente</h2>
+  <div>
+    <label class="block mb-1">Correo</label>
+    <input name="mail_email" value="{{ settings.mail.email }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Contraseña / Token</label>
+    <input type="password" name="mail_password" value="{{ settings.mail.password }}" class="border rounded w-full p-2">
+  </div>
+  <button name="action" value="save_mail" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+  <button name="action" value="test_mail" class="bg-green-600 text-white px-4 py-2 rounded">Probar</button>
+</form>
+<form method="post" class="space-y-4 mt-8">
+  <h2 class="text-xl font-semibold">Microsoft Graph / OneDrive</h2>
+  <div>
+    <label class="block mb-1">client_id</label>
+    <input name="client_id" value="{{ settings.onedrive.client_id }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">client_secret</label>
+    <input name="client_secret" value="{{ settings.onedrive.client_secret }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">tenant_id</label>
+    <input name="tenant_id" value="{{ settings.onedrive.tenant_id }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">user_id</label>
+    <input name="user_id" value="{{ settings.onedrive.user_id }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">redirect_uri</label>
+    <input name="redirect_uri" value="{{ settings.onedrive.redirect_uri }}" class="border rounded w-full p-2">
+  </div>
+  <button name="action" value="save_onedrive" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+  <button name="action" value="test_onedrive" class="bg-green-600 text-white px-4 py-2 rounded">Probar conexión</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add persistent settings file and setup utilities
- implement admin pages for categories, fields and connection credentials
- enforce configuration before inscriptions and use per-category OneDrive paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893696a8c448322bc391ebc0de5b1b7