### PR TITLE
Configure SMTP email settings

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -90,8 +90,11 @@ def settings():
         action = request.form.get('action')
         if action == 'test_mail':
             try:
-                email = cfg['onedrive'].get('user_id', '')
-                if not email or not _validate_microsoft_email(email):
+                email = cfg['mail'].get('mail_user', '')
+                password = cfg['mail'].get('mail_password', '')
+                if not email or not password:
+                    raise ValueError('Correo no configurado')
+                if not _validate_microsoft_email(email):
                     raise ValueError('El correo debe ser una cuenta de Microsoft')
                 from services.mail import test_connection as mail_test
 
@@ -101,6 +104,18 @@ def settings():
                 flash('Correo verificado')
             except Exception as e:
                 flash(f'Error: {e}')
+        elif action == 'save_mail':
+            email = request.form.get('mail_user', '')
+            if not email or not _validate_microsoft_email(email):
+                flash('El correo debe ser una cuenta de Microsoft')
+                return redirect(url_for('admin.settings'))
+            cfg['mail']['mail_user'] = email
+            cfg['mail']['mail_password'] = request.form.get('mail_password', '')
+            cfg['mail']['smtp_host'] = 'smtp.office365.com'
+            cfg['mail']['smtp_port'] = 587
+            cfg['mail']['tested'] = False
+            save_settings(cfg)
+            flash('Credenciales de correo guardadas')
         elif action == 'save_onedrive':
             email = request.form.get('user_id', '')
             if not email or not _validate_microsoft_email(email):

--- a/app/utils.py
+++ b/app/utils.py
@@ -38,7 +38,13 @@ def init_configs():
             json.dump(default_fields, f, ensure_ascii=False, indent=2)
     if not os.path.exists(SETTINGS_FILE):
         default_settings = {
-            "mail": {"tested": False},
+            "mail": {
+                "mail_user": "",
+                "mail_password": "",
+                "smtp_host": "smtp.office365.com",
+                "smtp_port": 587,
+                "tested": False,
+            },
             "onedrive": {
                 "client_id": "",
                 "client_secret": "",
@@ -89,7 +95,28 @@ def load_settings():
     if not os.path.exists(SETTINGS_FILE):
         init_configs()
     with open(SETTINGS_FILE, encoding='utf-8') as f:
-        return json.load(f)
+        data = json.load(f)
+    defaults = {
+        "mail": {
+            "mail_user": "",
+            "mail_password": "",
+            "smtp_host": "smtp.office365.com",
+            "smtp_port": 587,
+            "tested": False,
+        },
+        "onedrive": {
+            "client_id": "",
+            "client_secret": "",
+            "tenant_id": "",
+            "user_id": "",
+            "tested": False,
+        },
+    }
+    for section, values in defaults.items():
+        data.setdefault(section, {})
+        for k, v in values.items():
+            data[section].setdefault(k, v)
+    return data
 
 
 def save_settings(data):

--- a/services/mail.py
+++ b/services/mail.py
@@ -1,34 +1,35 @@
-import requests
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
 from app.utils import load_settings
-from .graph_auth import get_access_token, GraphAPIError
+
+
+def _get_cfg():
+    cfg = load_settings().get('mail', {})
+    user = cfg.get('mail_user')
+    password = cfg.get('mail_password')
+    host = cfg.get('smtp_host', 'smtp.office365.com')
+    port = cfg.get('smtp_port', 587)
+    if not user or not password:
+        raise ValueError('Correo no configurado')
+    return user, password, host, port
 
 
 def test_connection() -> None:
-    cfg = load_settings().get('onedrive', {})
-    email = cfg.get('user_id')
-    if not email:
-        raise ValueError('Correo no configurado')
-    token = get_access_token(cfg)
-    payload = {
-        "message": {
-            "subject": "Prueba de correo",
-            "body": {"contentType": "Text", "content": "Prueba de envío de correo."},
-            "toRecipients": [{"emailAddress": {"address": email}}],
-        },
-        "saveToSentItems": "false",
-    }
-    url = f"https://graph.microsoft.com/v1.0/users/{email}/sendMail"
-    r = requests.post(url, headers={'Authorization': f'Bearer {token}'}, json=payload)
-    if r.status_code >= 400:
-        raise GraphAPIError(r.status_code, r.text)
+    user, password, host, port = _get_cfg()
+    msg = MIMEText('Prueba de envío de correo.')
+    msg['Subject'] = 'Prueba de correo'
+    msg['From'] = user
+    msg['To'] = user
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(user, password)
+        server.send_message(msg)
 
 
 def send_mail(nombre, categoria, fields, file_links):
-    cfg = load_settings()['onedrive']
-    email = cfg.get('user_id')
-    if not email:
-        raise ValueError('Correo no configurado')
-    token = get_access_token(cfg)
+    user, password, host, port = _get_cfg()
     subject = f"Inscripción recibida: {nombre} - {categoria}"
     body = "<p>Se ha recibido una inscripción con los siguientes datos:</p><ul>"
     for label, value in fields.items():
@@ -37,15 +38,13 @@ def send_mail(nombre, categoria, fields, file_links):
     for link in file_links:
         body += f"<li><a href='{link}'>{link}</a></li>"
     body += "</ul>"
-    payload = {
-        "message": {
-            "subject": subject,
-            "body": {"contentType": "HTML", "content": body},
-            "toRecipients": [{"emailAddress": {"address": email}}],
-        },
-        "saveToSentItems": "false",
-    }
-    url = f"https://graph.microsoft.com/v1.0/users/{email}/sendMail"
-    r = requests.post(url, headers={'Authorization': f'Bearer {token}'}, json=payload)
-    if r.status_code >= 400:
-        raise GraphAPIError(r.status_code, r.text)
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = subject
+    msg['From'] = user
+    msg['To'] = user
+    msg.attach(MIMEText(body, 'html'))
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        server.login(user, password)
+        server.send_message(msg)
+

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,9 @@
 {
   "mail": {
+    "mail_user": "",
+    "mail_password": "",
+    "smtp_host": "smtp.office365.com",
+    "smtp_port": 587,
     "tested": false
   },
   "onedrive": {

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -5,9 +5,14 @@
 <form method="post" class="space-y-4">
   <h2 class="text-xl font-semibold">Correo remitente</h2>
   <div>
-    <label class="block mb-1">Correo</label>
-    <input value="{{ settings.onedrive.user_id }}" class="border rounded w-full p-2" disabled>
+    <label class="block mb-1">Correo remitente</label>
+    <input name="mail_user" value="{{ settings.mail.mail_user }}" class="border rounded w-full p-2">
   </div>
+  <div>
+    <label class="block mb-1">Contraseña</label>
+    <input name="mail_password" type="password" value="{{ settings.mail.mail_password }}" class="border rounded w-full p-2">
+  </div>
+  <button name="action" value="save_mail" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
   <button name="action" value="test_mail" class="bg-green-600 text-white px-4 py-2 rounded">Probar</button>
 </form>
 <form method="post" class="space-y-4 mt-8">


### PR DESCRIPTION
## Summary
- extend settings defaults and loader for SMTP credentials
- allow admins to save/test mail user and password
- switch mail service to SMTP with TLS authentication

## Testing
- `python -m py_compile app/utils.py app/admin/routes.py services/mail.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689394083a208322a51aa349c8a90924