### PR TITLE
Add dynamic text field management

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -91,6 +91,25 @@ def load_text_fields(cat):
     return data.get(cat, [])
 
 
+def save_text_fields(cat: str, fields: list) -> None:
+    """Persist text field configuration for a category.
+
+    Parameters
+    ----------
+    cat: str
+        Identifier of the category whose fields are being saved.
+    fields: list
+        List of dictionaries representing field metadata.
+    """
+    data = {}
+    if os.path.exists(FIELD_CONFIG):
+        with open(FIELD_CONFIG, encoding='utf-8') as f:
+            data = json.load(f)
+    data[cat] = fields
+    with open(FIELD_CONFIG, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
 def load_settings():
     if not os.path.exists(SETTINGS_FILE):
         init_configs()

--- a/templates/admin_fields.html
+++ b/templates/admin_fields.html
@@ -2,19 +2,57 @@
 {% block title %}Admin Campos{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Campos de texto por Categoría</h1>
-<form method="post" class="space-y-4">
-  <div>
-    <label class="block mb-1">Categoría</label>
-    <select name="category" class="border rounded w-full p-2">
-      {% for item in menu %}
-        <option value="{{ item.key }}">{{ item.name }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div>
-    <label class="block mb-1">Campos (JSON)</label>
-    <textarea name="fields" rows="6" class="border rounded w-full p-2">{{ fields|tojson(indent=2) }}</textarea>
-  </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+
+<form method="get" class="mb-4">
+  <label class="block mb-1">Categoría</label>
+  <select name="category" onchange="this.form.submit()" class="border rounded w-full p-2">
+    <option value="">-- Seleccione --</option>
+    {% for item in menu %}
+      <option value="{{ item.key }}" {% if item.key == selected_cat %}selected{% endif %}>{{ item.name }}</option>
+    {% endfor %}
+  </select>
 </form>
+
+{% if selected_cat %}
+  <div class="space-y-2">
+    {% for field in fields %}
+      <form method="post" class="flex items-center space-x-2">
+        <input type="hidden" name="category" value="{{ selected_cat }}">
+        <input type="hidden" name="index" value="{{ loop.index0 }}">
+        <input type="text" name="label" value="{{ field.label }}" placeholder="Etiqueta" class="border rounded p-1">
+        <input type="text" name="name" value="{{ field.name }}" placeholder="Nombre" class="border rounded p-1">
+        <select name="type" class="border rounded p-1">
+          <option value="text" {% if field.type == 'text' %}selected{% endif %}>Texto</option>
+          <option value="email" {% if field.type == 'email' %}selected{% endif %}>Email</option>
+          <option value="number" {% if field.type == 'number' %}selected{% endif %}>Número</option>
+        </select>
+        <label class="flex items-center space-x-1">
+          <input type="checkbox" name="required" {% if field.required %}checked{% endif %}>
+          <span>Obligatorio</span>
+        </label>
+        <button type="submit" name="action" value="up" class="px-2 py-1 bg-gray-200 rounded">↑</button>
+        <button type="submit" name="action" value="down" class="px-2 py-1 bg-gray-200 rounded">↓</button>
+        <button type="submit" name="action" value="update" class="bg-blue-600 text-white px-2 py-1 rounded">Guardar</button>
+        <button type="submit" name="action" value="delete" class="bg-red-600 text-white px-2 py-1 rounded">Eliminar</button>
+      </form>
+    {% endfor %}
+
+    <form method="post" class="flex items-center space-x-2 pt-2 border-t">
+      <input type="hidden" name="category" value="{{ selected_cat }}">
+      <input type="text" name="label" placeholder="Etiqueta" class="border rounded p-1">
+      <input type="text" name="name" placeholder="Nombre" class="border rounded p-1">
+      <select name="type" class="border rounded p-1">
+        <option value="text">Texto</option>
+        <option value="email">Email</option>
+        <option value="number">Número</option>
+      </select>
+      <label class="flex items-center space-x-1">
+        <input type="checkbox" name="required">
+        <span>Obligatorio</span>
+      </label>
+      <button type="submit" name="action" value="add" class="bg-green-600 text-white px-2 py-1 rounded">Agregar</button>
+    </form>
+  </div>
+{% endif %}
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- add utility to persist text field configs
- implement full CRUD for text fields per category in admin panel
- provide admin UI to add, edit, reorder and delete text fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689396d73a388322b72479acf72f0825