### PR TITLE
Store submissions and add admin view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+submissions.csv

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -8,6 +8,7 @@ from ..utils import (
     save_settings,
     load_text_fields,
     save_text_fields,
+    load_submissions,
     FILE_CONFIG,
     MENU_CONFIG,
 )
@@ -158,3 +159,19 @@ def settings():
                 flash(f'Error: {e}')
         return redirect(url_for('admin.settings'))
     return render_template('admin_settings.html', settings=cfg)
+
+
+@admin_bp.route('/submissions')
+def submissions():
+    menu = load_menu()
+    cat = request.args.get('category', '')
+    data = load_submissions(cat)
+    menu_map = {m['key']: m['name'] for m in menu}
+    for item in data:
+        item['category_name'] = menu_map.get(item['category'], item['category'])
+    return render_template(
+        'admin_submissions.html',
+        menu=menu,
+        submissions=data,
+        selected_cat=cat,
+    )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2,7 +2,13 @@ import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
 from werkzeug.utils import secure_filename
 
-from ..utils import load_menu, load_file_labels, load_text_fields, is_setup_complete
+from ..utils import (
+    load_menu,
+    load_file_labels,
+    load_text_fields,
+    is_setup_complete,
+    save_submission,
+)
 from services.onedrive import upload_files
 from services.mail import send_mail
 
@@ -62,7 +68,10 @@ def inscripcion(key):
                 return redirect(request.url)
 
         try:
-            folder_path, file_links = upload_files(nombre, key, cat.get('base_path', 'Inscripciones'), files)
+            folder_path, file_links = upload_files(
+                nombre, key, cat.get('base_path', 'Inscripciones'), files
+            )
+            save_submission(key, form_values, file_links)
             send_mail(nombre, cat['name'], form_values, file_links)
             flash('Enviado correctamente')
         except Exception as e:

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,6 +6,7 @@ MENU_CONFIG = 'menu_config.csv'
 FILE_CONFIG = 'file_config.csv'
 FIELD_CONFIG = 'field_config.json'
 SETTINGS_FILE = 'settings.json'
+SUBMISSIONS_FILE = 'submissions.csv'
 
 
 def init_configs():
@@ -108,6 +109,40 @@ def save_text_fields(cat: str, fields: list) -> None:
     data[cat] = fields
     with open(FIELD_CONFIG, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_submission(cat: str, fields: dict, files: list) -> None:
+    """Append a user submission to the submissions file."""
+    exists = os.path.exists(SUBMISSIONS_FILE)
+    with open(SUBMISSIONS_FILE, 'a', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        if not exists:
+            writer.writerow(['category', 'fields', 'files'])
+        writer.writerow([
+            cat,
+            json.dumps(fields, ensure_ascii=False),
+            json.dumps(files, ensure_ascii=False),
+        ])
+
+
+def load_submissions(cat: str = '') -> list:
+    """Return stored submissions, optionally filtered by category."""
+    if not os.path.exists(SUBMISSIONS_FILE):
+        return []
+    submissions = []
+    with open(SUBMISSIONS_FILE, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if cat and row['category'] != cat:
+                continue
+            submissions.append(
+                {
+                    'category': row['category'],
+                    'fields': json.loads(row['fields']),
+                    'files': json.loads(row['files']),
+                }
+            )
+    return submissions
 
 
 def load_settings():

--- a/templates/admin_submissions.html
+++ b/templates/admin_submissions.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}Inscripciones{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Inscripciones recibidas</h1>
+
+<form method="get" class="mb-4">
+  <label class="block mb-1">Categoría</label>
+  <select name="category" onchange="this.form.submit()" class="border rounded w-full p-2">
+    <option value="">-- Todas --</option>
+    {% for item in menu %}
+      <option value="{{ item.key }}" {% if item.key == selected_cat %}selected{% endif %}>{{ item.name }}</option>
+    {% endfor %}
+  </select>
+</form>
+
+{% if submissions %}
+  <div class="space-y-4">
+    {% for sub in submissions %}
+      <div class="border rounded p-2">
+        <h2 class="font-semibold mb-2">{{ sub.category_name }}</h2>
+        <ul class="mb-2">
+          {% for label, value in sub.fields.items() %}
+            <li><strong>{{ label }}:</strong> {{ value }}</li>
+          {% endfor %}
+        </ul>
+        {% if sub.files %}
+          <ul>
+            {% for link in sub.files %}
+              <li><a href="{{ link }}" class="text-blue-600" target="_blank">{{ link }}</a></li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+{% else %}
+  <p>No hay inscripciones.</p>
+{% endif %}
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,8 @@
         <a href="{{ url_for('main.index') }}" class="font-semibold hover:underline">Inicio</a>
         <a href="{{ url_for('admin.menu') }}" class="font-semibold hover:underline">Menú</a>
         <a href="{{ url_for('admin.files') }}" class="font-semibold hover:underline">Archivos</a>
+        <a href="{{ url_for('admin.fields') }}" class="font-semibold hover:underline">Campos</a>
+        <a href="{{ url_for('admin.submissions') }}" class="font-semibold hover:underline">Inscripciones</a>
       </div>
       <button id="toggleDark" class="px-2 py-1 border rounded">Modo</button>
     </div>


### PR DESCRIPTION
## Summary
- Persist user submissions in `submissions.csv` and expose helpers for saving and loading them
- Add admin page and navigation link to review stored submissions

## Testing
- `python -m py_compile app/utils.py app/main/routes.py app/admin/routes.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6893993d04e08322a2c6705dc19dc326