### PR TITLE
Add category CRUD and configurable credential testing

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -10,6 +10,7 @@ class Category(Base):
     key = Column(String, unique=True, nullable=False)
     name = Column(String, nullable=False)
     base_path = Column(String, default='')
+    active = Column(Boolean, default=True)
     parent_id = Column(Integer, ForeignKey('categories.id'))
     parent = relationship('Category', remote_side=[id], backref='children')
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,17 +3,28 @@ from .db import SessionLocal
 from .models import Category, FileField, TextField, Submission, Setting
 
 
-def load_menu():
+def load_menu(include_inactive: bool = False):
+    """Return list of categories.
+
+    Args:
+        include_inactive: When True include inactive categories.
+    """
     with SessionLocal() as db:
-        categories = db.query(Category).all()
+        query = db.query(Category)
+        if not include_inactive:
+            query = query.filter_by(active=True)
+        categories = query.all()
         result = []
         for c in categories:
             result.append(
                 {
+                    'id': c.id,
                     'key': c.key,
                     'name': c.name,
                     'parent': c.parent.key if c.parent else '',
+                    'parent_id': c.parent_id,
                     'base_path': c.base_path,
+                    'active': c.active,
                 }
             )
         return result

--- a/services/mail.py
+++ b/services/mail.py
@@ -16,8 +16,14 @@ def _get_cfg():
     return user, password, host, port
 
 
-def test_connection() -> None:
-    user, password, host, port = _get_cfg()
+def test_connection(
+    user: str | None = None,
+    password: str | None = None,
+    host: str = 'smtp.office365.com',
+    port: int = 587,
+) -> None:
+    if user is None or password is None:
+        user, password, host, port = _get_cfg()
     msg = MIMEText('Prueba de envío de correo.')
     msg['Subject'] = 'Prueba de correo'
     msg['From'] = user

--- a/templates/admin_category_edit.html
+++ b/templates/admin_category_edit.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block title %}Editar Categoría{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Editar Categoría</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block mb-1">Clave</label>
+    <input name="key" value="{{ category.key }}" required class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Nombre</label>
+    <input name="name" value="{{ category.name }}" required class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Categoría padre</label>
+    <select name="parent_id" class="border rounded w-full p-2">
+      <option value="">-- Raíz --</option>
+      {% macro opt(items, level=0) %}
+        {% for item in items %}
+          <option value="{{ item.id }}" {% if item.id == category.parent_id %}selected{% endif %}>{{ '-' * level }} {{ item.name }}</option>
+          {% if item.children %}
+            {{ opt(item.children, level + 1) }}
+          {% endif %}
+        {% endfor %}
+      {% endmacro %}
+      {{ opt(menu) }}
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Ruta base OneDrive</label>
+    <input name="base_path" value="{{ category.base_path }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="inline-flex items-center">
+      <input type="checkbox" name="active" {% if category.active %}checked{% endif %} class="mr-2">
+      Activa
+    </label>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
+  <a href="{{ url_for('admin.menu') }}" class="ml-2">Cancelar</a>
+</form>
+{% endblock %}

--- a/templates/admin_menu.html
+++ b/templates/admin_menu.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
-{% block title %}Admin Menú{% endblock %}
+{% block title %}Admin Categorías{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">Gestión de Categorías</h1>
-<form method="post" class="space-y-4">
+<form method="post" class="space-y-4 mb-8">
   <div>
     <label class="block mb-1">Clave</label>
     <input name="key" required class="border rounded w-full p-2">
@@ -12,27 +12,62 @@
     <input name="name" required class="border rounded w-full p-2">
   </div>
   <div>
-    <label class="block mb-1">Padre (vacío si es raíz)</label>
-    <input name="parent" class="border rounded w-full p-2">
+    <label class="block mb-1">Categoría padre</label>
+    <select name="parent_id" class="border rounded w-full p-2">
+      <option value="">-- Raíz --</option>
+      {% macro opt(items, level=0) %}
+        {% for item in items %}
+          <option value="{{ item.id }}">{{ '-' * level }} {{ item.name }}</option>
+          {% if item.children %}
+            {{ opt(item.children, level + 1) }}
+          {% endif %}
+        {% endfor %}
+      {% endmacro %}
+      {{ opt(menu) }}
+    </select>
   </div>
   <div>
     <label class="block mb-1">Ruta base OneDrive</label>
     <input name="base_path" class="border rounded w-full p-2">
   </div>
+  <div>
+    <label class="inline-flex items-center">
+      <input type="checkbox" name="active" checked class="mr-2">
+      Activa
+    </label>
+  </div>
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Agregar</button>
 </form>
-<h2 class="text-xl font-semibold mt-8 mb-2">Categorías existentes</h2>
-{% macro render(items) %}
-<ul class="list-disc pl-5">
-  {% for item in items %}
-    <li>
-      {{ item.name }} (clave: {{ item.key }}, padre: {{ item.parent }}, ruta: {{ item.base_path }})
-      {% if item.children %}
-        {{ render(item.children) }}
-      {% endif %}
-    </li>
-  {% endfor %}
-</ul>
-{% endmacro %}
-{{ render(menu) }}
+<h2 class="text-xl font-semibold mb-2">Categorías existentes</h2>
+<table class="min-w-full bg-white dark:bg-gray-800">
+  <thead>
+    <tr class="border-b">
+      <th class="text-left p-2">Nombre</th>
+      <th class="text-left p-2">Clave</th>
+      <th class="text-left p-2">Activa</th>
+      <th class="text-left p-2">Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% macro row(item, level=0) %}
+      <tr class="border-b">
+        <td class="p-2" style="padding-left: {{ level*20 }}px">{{ item.name }}</td>
+        <td class="p-2">{{ item.key }}</td>
+        <td class="p-2">{{ 'Sí' if item.active else 'No' }}</td>
+        <td class="p-2 space-x-2">
+          <a href="{{ url_for('admin.edit_category', cat_id=item.id) }}" class="text-blue-600">Editar</a>
+          <form action="{{ url_for('admin.delete_category', cat_id=item.id) }}" method="post" class="inline">
+            <button class="text-red-600" onclick="return confirm('¿Desactivar categoría?')">Desactivar</button>
+          </form>
+        </td>
+      </tr>
+      {% for c in item.children %}
+        {{ row(c, level + 1) }}
+      {% endfor %}
+    {% endmacro %}
+    {% for item in menu %}
+      {{ row(item) }}
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
       <div class="space-x-4">
         <a href="{{ url_for('main.index') }}" class="font-semibold hover:underline">Inicio</a>
-        <a href="{{ url_for('admin.menu') }}" class="font-semibold hover:underline">Menú</a>
+        <a href="{{ url_for('admin.menu') }}" class="font-semibold hover:underline">Categorías</a>
         <a href="{{ url_for('admin.files') }}" class="font-semibold hover:underline">Archivos</a>
         <a href="{{ url_for('admin.fields') }}" class="font-semibold hover:underline">Campos</a>
         <a href="{{ url_for('admin.submissions') }}" class="font-semibold hover:underline">Inscripciones</a>


### PR DESCRIPTION
## Summary
- implement full CRUD for categories with hierarchy and active flag
- allow editing SMTP and Microsoft Graph settings with validation before saving
- add mail connection helper that accepts credentials for testing

## Testing
- `python -m py_compile app/models.py app/utils.py app/admin/routes.py services/mail.py`
- `python - <<'PY'\nfrom app import create_app\napp=create_app()\nprint('app created')\nPY` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask sqlalchemy requests` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_b_6893d33520b08322837e6b9244545ebd