### PR TITLE
feat: configurable SMTP and category notifications

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -8,6 +8,7 @@ from ..utils import (
     load_text_fields,
     is_setup_complete,
     save_submission,
+    load_settings,
 )
 from services.onedrive import upload_files
 from services.mail import send_mail
@@ -78,11 +79,13 @@ def inscripcion(key):
             return redirect(request.url)
 
         try:
+            cfg = load_settings()
+            base_path = cat.get('base_path') or cfg['onedrive'].get('base_path', 'Inscripciones')
             folder_path, file_links = upload_files(
-                nombre, key, cat.get('base_path', 'Inscripciones'), uploaded_files
+                nombre, key, base_path, uploaded_files
             )
             save_submission(key, form_values, file_links)
-            send_mail(nombre, cat['name'], form_values, file_links)
+            send_mail(nombre, cat['name'], form_values, file_links, cat.get('notify_emails', ''))
             flash('Enviado correctamente')
         except Exception as e:
             flash(f'Error: {str(e)}')

--- a/app/models.py
+++ b/app/models.py
@@ -10,6 +10,7 @@ class Category(Base):
     key = Column(String, unique=True, nullable=False)
     name = Column(String, nullable=False)
     base_path = Column(String, default='')
+    notify_emails = Column(String, default='')
     active = Column(Boolean, default=True)
     parent_id = Column(Integer, ForeignKey('categories.id'))
     parent = relationship('Category', remote_side=[id], backref='children')

--- a/app/utils.py
+++ b/app/utils.py
@@ -24,6 +24,7 @@ def load_menu(include_inactive: bool = False):
                     'parent': c.parent.key if c.parent else '',
                     'parent_id': c.parent_id,
                     'base_path': c.base_path,
+                    'notify_emails': c.notify_emails,
                     'active': c.active,
                 }
             )
@@ -149,6 +150,7 @@ def load_settings():
             "client_secret": "",
             "tenant_id": "",
             "user_id": "",
+            "base_path": "Inscripciones",
             "tested": False,
             "updated_at": "",
             "tested_at": "",

--- a/services/mail.py
+++ b/services/mail.py
@@ -34,8 +34,13 @@ def test_connection(
         server.send_message(msg)
 
 
-def send_mail(nombre, categoria, fields, file_links):
+def send_mail(nombre, categoria, fields, file_links, recipients=None):
     user, password, host, port = _get_cfg()
+    if recipients:
+        if isinstance(recipients, str):
+            recipients = [r.strip() for r in recipients.split(',') if r.strip()]
+    else:
+        recipients = [user]
     subject = f"Inscripción recibida: {nombre} - {categoria}"
     body = "<p>Se ha recibido una inscripción con los siguientes datos:</p><ul>"
     for label, value in fields.items():
@@ -47,7 +52,7 @@ def send_mail(nombre, categoria, fields, file_links):
     msg = MIMEMultipart('alternative')
     msg['Subject'] = subject
     msg['From'] = user
-    msg['To'] = user
+    msg['To'] = ", ".join(recipients)
     msg.attach(MIMEText(body, 'html'))
     with smtplib.SMTP(host, port) as server:
         server.starttls()

--- a/templates/admin_category_edit.html
+++ b/templates/admin_category_edit.html
@@ -31,6 +31,10 @@
     <input name="base_path" value="{{ category.base_path }}" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Correos de notificación (separados por comas)</label>
+    <input name="notify_emails" value="{{ category.notify_emails }}" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="inline-flex items-center">
       <input type="checkbox" name="active" {% if category.active %}checked{% endif %} class="mr-2">
       Activa

--- a/templates/admin_menu.html
+++ b/templates/admin_menu.html
@@ -31,6 +31,10 @@
     <input name="base_path" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Correos de notificación (separados por comas)</label>
+    <input name="notify_emails" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="inline-flex items-center">
       <input type="checkbox" name="active" checked class="mr-2">
       Activa

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -16,6 +16,14 @@
     <label class="block mb-1">Contraseña</label>
     <input name="mail_password" type="password" value="{{ settings.mail.mail_password }}" class="border rounded w-full p-2">
   </div>
+  <div>
+    <label class="block mb-1">Servidor SMTP</label>
+    <input name="smtp_host" value="{{ settings.mail.smtp_host }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Puerto SMTP</label>
+    <input name="smtp_port" value="{{ settings.mail.smtp_port }}" class="border rounded w-full p-2">
+  </div>
   <button name="action" value="save_mail" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
   <button name="action" value="test_mail" class="bg-green-600 text-white px-4 py-2 rounded">Probar</button>
 </form>
@@ -40,6 +48,10 @@
   <div>
     <label class="block mb-1">user_id</label>
     <input name="user_id" value="{{ settings.onedrive.user_id }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Ruta base</label>
+    <input name="base_path" value="{{ settings.onedrive.base_path }}" class="border rounded w-full p-2">
   </div>
   <button name="action" value="save_onedrive" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
   <button name="action" value="test_onedrive" class="bg-green-600 text-white px-4 py-2 rounded">Probar conexión</button>


### PR DESCRIPTION
## Summary
- allow administrators to configure SMTP server, port and OneDrive base folder
- permit changing Microsoft Graph credentials and test before saving
- add per-category notification recipients used when sending emails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689652be6c54832283f73e7c61e12f2b