### PR TITLE
Improve flash messages and error reporting for inscriptions

### DIFF
--- a/services/mail.py
+++ b/services/mail.py
@@ -63,7 +63,7 @@ def send_mail(nombre, categoria, fields, file_links, recipients=None):
             server.login(user, password)
             server.send_message(msg)
         return True
-    except smtplib.SMTPException as e:
+    except Exception as e:
         logger.exception("Error enviando correo")
-        raise RuntimeError("Error enviando correo") from e
+        raise RuntimeError(f"Error enviando correo: {e}") from e
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,11 +22,15 @@
     </div>
   </nav>
   <main class="container mx-auto px-4 flex-1">
-    {% with messages = get_flashed_messages() %}
+    {% with messages = get_flashed_messages(with_categories=True) %}
       {% if messages %}
         <div class="mb-4">
-          {% for message in messages %}
-            <div class="bg-green-100 text-green-800 p-2 rounded mb-2">{{ message }}</div>
+          {% for category, message in messages %}
+            {% if category == 'error' %}
+              <div class="bg-red-100 text-red-800 p-2 rounded mb-2">{{ message }}</div>
+            {% else %}
+              <div class="bg-green-100 text-green-800 p-2 rounded mb-2">{{ message }}</div>
+            {% endif %}
           {% endfor %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Display flash messages with categories in the base template
- Provide detailed error messages for OneDrive uploads and email sending
- Show clear success confirmation when inscription completes

## Testing
- `python -m py_compile app/main/routes.py services/mail.py`


------
https://chatgpt.com/codex/tasks/task_b_6896616e8e8c8322be431344671b829d