### PR TITLE
Improve Graph integration error handling and messaging

### DIFF
--- a/services/mail.py
+++ b/services/mail.py
@@ -1,9 +1,10 @@
 import logging
 import smtplib
-from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+import requests
 
 from app.utils import load_settings
+from .graph_auth import GraphAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +38,12 @@ def test_connection(
         server.send_message(msg)
 
 
-def send_mail(nombre, categoria, fields, file_links, recipients=None):
-    print('send_mail() llamado')
-    user, password, host, port = _get_cfg()
-    if recipients:
-        if isinstance(recipients, str):
-            recipients = [r.strip() for r in recipients.split(',') if r.strip()]
-    else:
-        recipients = [user]
-    subject = f"Inscripción recibida: {nombre} - {categoria}"
+def send_mail(token, user_id, nombre, categoria, fields, file_links, to_recipients, cc_recipients=None):
+    """Envía un correo usando Microsoft Graph."""
+    if cc_recipients is None:
+        cc_recipients = []
+    url = f"https://graph.microsoft.com/v1.0/users/{user_id}/sendMail"
+    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
     body = "<p>Se ha recibido una inscripción con los siguientes datos:</p><ul>"
     for label, value in fields.items():
         body += f"<li><strong>{label}:</strong> {value}</li>"
@@ -53,25 +51,23 @@ def send_mail(nombre, categoria, fields, file_links, recipients=None):
     for link in file_links:
         body += f"<li><a href='{link}'>{link}</a></li>"
     body += "</ul>"
-    msg = MIMEMultipart('alternative')
-    msg['Subject'] = subject
-    msg['From'] = user
-    msg['To'] = ", ".join(recipients)
-    msg.attach(MIMEText(body, 'html'))
+    msg = {
+        "message": {
+            "subject": f"Inscripción recibida: {nombre} - {categoria}",
+            "body": {"contentType": "HTML", "content": body},
+            "toRecipients": [{"emailAddress": {"address": e}} for e in to_recipients],
+            "ccRecipients": [{"emailAddress": {"address": e}} for e in cc_recipients],
+        },
+        "saveToSentItems": "true",
+    }
     try:
-        with smtplib.SMTP(host, port) as server:
-            server.starttls()
-            server.login(user, password)
-            server.send_message(msg)
-        print('send_mail() completado')
-        return True
-    except Exception as e:
-        logger.exception(
-            "Error enviando correo", extra={
-                "recipients": recipients,
-                "host": host,
-                "port": port,
-            },
-        )
-        return False
+        response = requests.post(url, headers=headers, json=msg)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        status = getattr(e.response, 'status_code', 0)
+        text = getattr(e.response, 'text', str(e))
+        logger.exception("Error enviando correo")
+        raise GraphAPIError(status, text) from e
+    logger.info("Correo enviado: %s", ", ".join(to_recipients + cc_recipients))
+    return True
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,15 +22,11 @@
     </div>
   </nav>
   <main class="container mx-auto px-4 flex-1">
-    {% with messages = get_flashed_messages(with_categories=True) %}
+    {% with messages = get_flashed_messages() %}
       {% if messages %}
-        <div class="mb-4">
-          {% for category, message in messages %}
-            {% if category == 'error' %}
-              <div class="bg-red-100 text-red-800 p-2 rounded mb-2">{{ message }}</div>
-            {% else %}
-              <div class="bg-green-100 text-green-800 p-2 rounded mb-2">{{ message }}</div>
-            {% endif %}
+        <div class="mb-4 flashes">
+          {% for message in messages %}
+            <div class="bg-blue-100 text-blue-800 p-2 rounded mb-2 alert alert-info">{{ message }}</div>
           {% endfor %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- Display flash messages in base template
- Fetch Microsoft Graph token per submission and validate configuration before processing
- Harden OneDrive uploads and email sending with `raise_for_status` and detailed logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6896727970f483229b50c6e6f0463f7e