### PR TITLE
Fix OneDrive test import and Graph token validation

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -95,8 +95,11 @@ def inscripcion(key):
         base_path = cat.get('base_path') or drive_cfg.get('base_path')
         recipients_cfg = cat.get('notify_emails', '').strip()
         if not (
-            all([mail_cfg.get('mail_user'), mail_cfg.get('mail_password')])
-            and all(drive_cfg.get(k) for k in ('client_id', 'client_secret', 'tenant_id', 'user_id'))
+            mail_cfg.get('tested')
+            and all(
+                drive_cfg.get(k)
+                for k in ('client_id', 'client_secret', 'tenant_id', 'user_id')
+            )
             and base_path
             and recipients_cfg
         ):

--- a/services/graph_auth.py
+++ b/services/graph_auth.py
@@ -42,5 +42,8 @@ def get_access_token(cfg=None):
         logger.exception("Error obteniendo token de Graph")
         raise GraphAPIError(status, text) from e
     token = response.json().get('access_token')
+    if not token:
+        logger.error("No se recibió el token de acceso")
+        raise GraphAPIError(getattr(response, 'status_code', 0), 'Token no recibido')
     logger.info("Token de Graph obtenido")
     return token

--- a/services/onedrive.py
+++ b/services/onedrive.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 from werkzeug.utils import secure_filename
-from .graph_auth import GraphAPIError
+from .graph_auth import GraphAPIError, get_access_token
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure OneDrive test_connection imports get_access_token
- validate Graph access token before using it
- check mail configuration using tested flag only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_689697ebc34483228479fdcb14c2302a