### PR TITLE
Support CC recipients and normalize OneDrive paths

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ class Category(Base):
     name = Column(String, nullable=False)
     base_path = Column(String, default='')
     notify_emails = Column(String, default='')
+    notify_cc_emails = Column(String, default='')
     active = Column(Boolean, default=True)
     parent_id = Column(Integer, ForeignKey('categories.id'))
     parent = relationship('Category', remote_side=[id], backref='children')

--- a/app/utils.py
+++ b/app/utils.py
@@ -25,6 +25,7 @@ def load_menu(include_inactive: bool = False):
                     'parent_id': c.parent_id,
                     'base_path': c.base_path,
                     'notify_emails': c.notify_emails,
+                    'notify_cc_emails': c.notify_cc_emails,
                     'active': c.active,
                 }
             )

--- a/templates/admin_category_edit.html
+++ b/templates/admin_category_edit.html
@@ -35,6 +35,10 @@
     <input name="notify_emails" value="{{ category.notify_emails }}" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Correos CC (separados por comas)</label>
+    <input name="notify_cc_emails" value="{{ category.notify_cc_emails }}" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="inline-flex items-center">
       <input type="checkbox" name="active" {% if category.active %}checked{% endif %} class="mr-2">
       Activa

--- a/templates/admin_menu.html
+++ b/templates/admin_menu.html
@@ -35,6 +35,10 @@
     <input name="notify_emails" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Correos CC (separados por comas)</label>
+    <input name="notify_cc_emails" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="inline-flex items-center">
       <input type="checkbox" name="active" checked class="mr-2">
       Activa


### PR DESCRIPTION
## Summary
- Add `notify_cc_emails` field for categories with admin UI to manage CC recipients
- Normalize OneDrive paths and avoid duplications with new helper and updated upload logic
- Pass CC recipients during inscription mail sending

## Testing
- `python -m py_compile services/onedrive.py app/main/routes.py app/utils.py app/models.py app/admin/routes.py`


------
https://chatgpt.com/codex/tasks/task_b_689b6a3e15f083229659b38e5f42d520