### PR TITLE
Remove global OneDrive base path configuration

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -257,7 +257,6 @@ def settings():
             client_id = request.form.get('client_id', '').strip()
             client_secret = request.form.get('client_secret', '').strip()
             tenant_id = request.form.get('tenant_id', '').strip()
-            base_path = request.form.get('base_path', '').strip() or 'Inscripciones'
             try:
                 from services.onedrive import test_connection as drive_test
 
@@ -270,7 +269,6 @@ def settings():
             cfg['onedrive']['client_secret'] = client_secret
             cfg['onedrive']['tenant_id'] = tenant_id
             cfg['onedrive']['user_id'] = email
-            cfg['onedrive']['base_path'] = base_path
             cfg['onedrive']['tested'] = True
             cfg['onedrive']['updated_at'] = datetime.now().isoformat()
             cfg['onedrive']['tested_at'] = datetime.now().isoformat()
@@ -282,7 +280,6 @@ def settings():
             client_secret = request.form.get('client_secret', '').strip() or cfg['onedrive'].get('client_secret', '')
             tenant_id = request.form.get('tenant_id', '').strip() or cfg['onedrive'].get('tenant_id', '')
             user_id = request.form.get('user_id', '').strip() or cfg['onedrive'].get('user_id', '')
-            base_path = request.form.get('base_path', '').strip() or cfg['onedrive'].get('base_path', 'Inscripciones')
             try:
                 from services.onedrive import test_connection as drive_test
 
@@ -295,7 +292,6 @@ def settings():
             cfg['onedrive']['client_secret'] = client_secret
             cfg['onedrive']['tenant_id'] = tenant_id
             cfg['onedrive']['user_id'] = user_id
-            cfg['onedrive']['base_path'] = base_path
             return render_template('admin_settings.html', settings=cfg)
         return redirect(url_for('admin.settings'))
     return render_template('admin_settings.html', settings=cfg)
@@ -331,8 +327,8 @@ def test_onedrive():
             return redirect(request.url)
         try:
             token = get_access_token(cfg)
-            base_path = cfg.get('base_path', 'Inscripciones')
-            dest_path = normalize_path(base_path, 'Test', 'Prueba')
+            temp_folder = datetime.now().strftime('%Y%m%d%H%M%S')
+            dest_path = normalize_path('Test', temp_folder)
             upload_files(token, cfg['user_id'], dest_path, [f])
             flash('Archivo de prueba subido correctamente')
         except GraphAPIError as e:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -98,7 +98,11 @@ def inscripcion(key):
         cfg = load_settings()
         mail_cfg = cfg.get('mail', {})
         drive_cfg = cfg.get('onedrive', {})
-        raw_base = cat.get('base_path') or drive_cfg.get('base_path', '')
+        raw_base = cat.get('base_path', '').strip()
+        if not raw_base:
+            current_app.logger.error('Categoría sin ruta base configurada')
+            flash('Categoría sin ruta base configurada', 'error')
+            return redirect(request.url)
         base_path = normalize_path(raw_base)
         recipients_cfg = cat.get('notify_emails', '').strip()
         cc_cfg = cat.get('notify_cc_emails', '').strip()
@@ -108,8 +112,6 @@ def inscripcion(key):
             missing.append('correo')
         if not all(drive_cfg.get(k) for k in ('client_id', 'client_secret', 'tenant_id', 'user_id')):
             missing.append('credenciales de OneDrive')
-        if not base_path:
-            missing.append('ruta base de OneDrive')
         if not recipients_cfg and not cc_cfg:
             missing.append('destinatarios')
         if missing:

--- a/app/utils.py
+++ b/app/utils.py
@@ -151,7 +151,6 @@ def load_settings():
             "client_secret": "",
             "tenant_id": "",
             "user_id": "",
-            "base_path": "Inscripciones",
             "tested": False,
             "updated_at": "",
             "tested_at": "",

--- a/templates/admin_settings.html
+++ b/templates/admin_settings.html
@@ -49,10 +49,6 @@
     <label class="block mb-1">user_id</label>
     <input name="user_id" value="{{ settings.onedrive.user_id }}" class="border rounded w-full p-2">
   </div>
-  <div>
-    <label class="block mb-1">Ruta base</label>
-    <input name="base_path" value="{{ settings.onedrive.base_path }}" class="border rounded w-full p-2">
-  </div>
   <button name="action" value="save_onedrive" class="bg-blue-600 text-white px-4 py-2 rounded">Guardar</button>
   <button name="action" value="test_onedrive" class="bg-green-600 text-white px-4 py-2 rounded">Probar conexión</button>
 </form>


### PR DESCRIPTION
## Summary
- drop global OneDrive `base_path` setting and related form fields
- require categories to define their own base path when uploading
- adjust OneDrive test upload to use a timestamped path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b7238a24c8322a77a98f2e26489cf