### PR TITLE
feat: add log entries and file renaming

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,14 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime, JSON
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Boolean,
+    ForeignKey,
+    DateTime,
+    JSON,
+    Text,
+)
 from sqlalchemy.orm import relationship
 from .db import Base
 
@@ -12,6 +21,7 @@ class Category(Base):
     base_path = Column(String, default='')
     notify_emails = Column(String, default='')
     notify_cc_emails = Column(String, default='')
+    file_pattern = Column(String, default='')
     active = Column(Boolean, default=True)
     parent_id = Column(Integer, ForeignKey('categories.id'))
     parent = relationship('Category', remote_side=[id], backref='children')
@@ -59,3 +69,21 @@ class Submission(Base):
     user = Column(String, default='')
     created_at = Column(DateTime, default=datetime.utcnow)
     category = relationship('Category')
+
+
+class LogEntry(Base):
+    __tablename__ = 'log_entries'
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    categoria_key = Column(String, nullable=False)
+    categoria_nombre = Column(String, nullable=False)
+    solicitante_nombre = Column(String, nullable=False)
+    solicitante_email = Column(String, default='')
+    one_drive_path = Column(String, default='')
+    one_drive_folder_url = Column(String, default='')
+    archivos = Column(JSON, nullable=False)
+    estado = Column(String, nullable=False)
+    detalle_error = Column(Text)
+    destinatarios_to = Column(JSON, default=list)
+    destinatarios_cc = Column(JSON, default=list)
+    user_admin = Column(String, default='')

--- a/templates/admin_category_edit.html
+++ b/templates/admin_category_edit.html
@@ -31,6 +31,10 @@
     <input name="base_path" value="{{ category.base_path }}" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Patrón de nombre de archivo</label>
+    <input name="file_pattern" value="{{ category.file_pattern or '' }}" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="block mb-1">Correos de notificación (separados por comas)</label>
     <input name="notify_emails" value="{{ category.notify_emails }}" class="border rounded w-full p-2">
   </div>

--- a/templates/admin_log_detail.html
+++ b/templates/admin_log_detail.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block title %}Detalle Bitácora{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Detalle de inscripción</h1>
+<p><strong>Fecha:</strong> {{ entry.timestamp }}</p>
+<p><strong>Categoría:</strong> {{ entry.categoria_nombre }} ({{ entry.categoria_key }})</p>
+<p><strong>Solicitante:</strong> {{ entry.solicitante_nombre }} {{ entry.solicitante_email }}</p>
+<p><strong>Estado:</strong> {{ entry.estado }}</p>
+{% if entry.detalle_error %}<p><strong>Error:</strong> {{ entry.detalle_error }}</p>{% endif %}
+{% if entry.one_drive_folder_url %}
+<p><strong>Carpeta:</strong> <a href="{{ entry.one_drive_folder_url }}" class="text-blue-600" target="_blank">{{ entry.one_drive_folder_url }}</a></p>
+{% endif %}
+<h2 class="font-semibold mt-4">Archivos</h2>
+<ul class="mb-2">
+{% for f in entry.archivos %}
+  <li>{{ f.nombre_final if f.nombre_final is defined else f.get('nombre_final') }} ({{ f.size_bytes if f.size_bytes is defined else f.get('size_bytes') }} bytes)</li>
+{% endfor %}
+</ul>
+<h2 class="font-semibold">Destinatarios</h2>
+<p><strong>To:</strong> {{ entry.destinatarios_to|join(', ') }}</p>
+<p><strong>CC:</strong> {{ entry.destinatarios_cc|join(', ') }}</p>
+<a href="{{ url_for('admin.logs_view') }}" class="text-blue-600">Volver</a>
+{% endblock %}

--- a/templates/admin_logs.html
+++ b/templates/admin_logs.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block title %}Bitácora{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Bitácora</h1>
+<form method="get" class="mb-4 space-y-2">
+  <div>
+    <label class="block mb-1">Categoría</label>
+    <select name="category" onchange="this.form.submit()" class="border rounded w-full p-2">
+      <option value="">-- Todas --</option>
+      {% for item in menu %}
+        <option value="{{ item.key }}" {% if item.key == selected_cat %}selected{% endif %}>{{ item.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="block mb-1">Buscar (nombre o email)</label>
+    <input name="search" value="{{ search }}" class="border rounded w-full p-2">
+  </div>
+  <div>
+    <label class="block mb-1">Estado</label>
+    <select name="status" class="border rounded w-full p-2">
+      <option value="">-- Todos --</option>
+      <option value="EXITO" {% if selected_status == 'EXITO' %}selected{% endif %}>Éxito</option>
+      <option value="ERROR" {% if selected_status == 'ERROR' %}selected{% endif %}>Error</option>
+    </select>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Filtrar</button>
+  <a href="{{ url_for('admin.logs_view', category=selected_cat, search=search, status=selected_status, export=1) }}" class="ml-2">Exportar CSV</a>
+</form>
+
+{% if logs %}
+<table class="min-w-full bg-white dark:bg-gray-800">
+  <thead>
+    <tr class="border-b">
+      <th class="p-2 text-left">Fecha/Hora</th>
+      <th class="p-2 text-left">Categoría</th>
+      <th class="p-2 text-left">Nombre</th>
+      <th class="p-2 text-left">Estado</th>
+      <th class="p-2 text-left">Archivos</th>
+      <th class="p-2 text-left">Correo</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for e in logs %}
+    <tr class="border-b">
+      <td class="p-2"><a href="{{ url_for('admin.log_detail', log_id=e.id) }}" class="text-blue-600">{{ e.timestamp }}</a></td>
+      <td class="p-2">{{ e.categoria_nombre }}</td>
+      <td class="p-2">{{ e.solicitante_nombre }}</td>
+      <td class="p-2">{{ e.estado }}</td>
+      <td class="p-2">{{ e.archivos|length }}</td>
+      <td class="p-2">{{ 'Sí' if e.destinatarios_to or e.destinatarios_cc else 'No' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No hay registros.</p>
+{% endif %}
+{% endblock %}

--- a/templates/admin_menu.html
+++ b/templates/admin_menu.html
@@ -31,6 +31,10 @@
     <input name="base_path" class="border rounded w-full p-2">
   </div>
   <div>
+    <label class="block mb-1">Patrón de nombre de archivo</label>
+    <input name="file_pattern" class="border rounded w-full p-2">
+  </div>
+  <div>
     <label class="block mb-1">Correos de notificación (separados por comas)</label>
     <input name="notify_emails" class="border rounded w-full p-2">
   </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
         <a href="{{ url_for('admin.files') }}" class="font-semibold hover:underline">Archivos</a>
         <a href="{{ url_for('admin.fields') }}" class="font-semibold hover:underline">Campos</a>
         <a href="{{ url_for('admin.submissions') }}" class="font-semibold hover:underline">Inscripciones</a>
+        <a href="{{ url_for('admin.logs_view') }}" class="font-semibold hover:underline">Bitácora</a>
         <div class="relative inline-block group">
           <span class="font-semibold hover:underline cursor-pointer">Test</span>
           <div class="absolute hidden group-hover:block bg-white dark:bg-gray-700 shadow-md mt-2">


### PR DESCRIPTION
## Summary
- log entries model and admin bitácora with CSV export
- configurable file pattern for uploaded files

## Testing
- `python -m py_compile app/models.py app/utils.py app/admin/routes.py app/main/routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b839df0448322b2be75c942a3168f