### PR TITLE
feat: configurable file names and templated emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Las variables pueden definirse en el entorno o en un archivo `.env` (no versiona
 
 La ruta final en OneDrive se construye como `base_path/categoria/nombre`.
 
+### Configuración de archivos
+En `/admin/files` puede definirse para cada archivo requerido un **Nombre final**. Este valor se utiliza para renombrar el archivo al almacenarlo y también al reemplazar la variable `{label}` en el patrón de nombres configurado en la categoría.
+
+### Plantillas de correo
+El correo de notificación se genera a partir de una plantilla Jinja ubicada en `templates/emails/inscripcion.html`. La plantilla recibe las variables `nombre`, `categoria`, `fields` y `folder_link`, permitiendo personalizar el contenido del mensaje.
+
 ## Inicialización de la base de datos
 ```bash
 python -c "from app.db import init_db; init_db()"

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -135,6 +135,7 @@ def files():
             label = request.form.get('label', '').strip()
             description = request.form.get('description', '').strip()
             required = bool(request.form.get('required'))
+            storage_name = request.form.get('storage_name', '').strip()
             if not name or not label:
                 flash('Nombre e identificador son obligatorios')
                 return redirect(url_for('admin.files', category=cat))
@@ -143,6 +144,7 @@ def files():
                 'label': label,
                 'description': description,
                 'required': required,
+                'storage_name': storage_name,
             }
             if action == 'add':
                 files_data.append(file_cfg)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -95,13 +95,15 @@ def inscripcion(key):
                 content = f.read()
                 size = len(content)
                 pattern = cat.get('file_pattern', '')
+                storage_name = fcfg.get('storage_name', '').strip()
                 final_name = filename
                 if pattern:
                     now = datetime.utcnow()
                     final_name = pattern
+                    label_value = storage_name or fcfg['label']
                     final_name = final_name.replace('{categoria}', cat['key'])
                     final_name = final_name.replace('{nombre}', nombre)
-                    final_name = final_name.replace('{label}', fcfg['label'])
+                    final_name = final_name.replace('{label}', label_value)
                     final_name = re.sub(
                         r'{fecha(?::([^}]+))?}',
                         lambda m: now.strftime(m.group(1) or '%Y%m%d'),
@@ -115,6 +117,12 @@ def inscripcion(key):
                     final_name = f"{final_name}{ext}"
                     while final_name in used_names:
                         final_name = f"{os.path.splitext(final_name)[0]}-{uuid.uuid4().hex[:4]}{ext}"
+                else:
+                    base = storage_name or os.path.splitext(filename)[0]
+                    base = re.sub(r'[\\/:*?"<>|]', '_', base)
+                    final_name = f"{base}{ext}"
+                    while final_name in used_names:
+                        final_name = f"{base}-{uuid.uuid4().hex[:4]}{ext}"
                 used_names.add(final_name)
                 file_info.append({"name": final_name, "size": size})
                 file_records.append(

--- a/app/models.py
+++ b/app/models.py
@@ -34,6 +34,7 @@ class FileField(Base):
     name = Column(String, nullable=False)
     label = Column(String, nullable=False)
     description = Column(String, default='')
+    storage_name = Column(String, default='')
     required = Column(Boolean, default=False)
     order = Column(Integer, default=0)
     category = relationship('Category', backref='file_fields')

--- a/app/utils.py
+++ b/app/utils.py
@@ -51,6 +51,7 @@ def load_file_fields(cat_key: str) -> list:
                 'label': f.label,
                 'description': f.description,
                 'required': f.required,
+                'storage_name': f.storage_name,
             }
             for f in fields
         ]

--- a/services/mail.py
+++ b/services/mail.py
@@ -3,6 +3,7 @@ import smtplib
 from email.mime.text import MIMEText
 import base64
 import requests
+from flask import render_template
 
 from app.utils import load_settings
 from .graph_auth import GraphAPIError, get_access_token
@@ -85,18 +86,23 @@ def send_mail(
     attachments,
     to_recipients,
     cc_recipients=None,
+    template: str = "emails/inscripcion.html",
 ):
     """Envía un correo usando Microsoft Graph."""
     if cc_recipients is None:
         cc_recipients = []
     url = f"https://graph.microsoft.com/v1.0/users/{user_id}/sendMail"
-    headers = {'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'}
-    body = "<p>Se ha recibido una inscripción con los siguientes datos:</p><ul>"
-    for label, value in fields.items():
-        body += f"<li><strong>{label}:</strong> {value}</li>"
-    body += "</ul>"
-    if folder_link:
-        body += f"<p>Carpeta en OneDrive: <a href='{folder_link}'>{folder_link}</a></p>"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    body = render_template(
+        template,
+        nombre=nombre,
+        categoria=categoria,
+        fields=fields,
+        folder_link=folder_link,
+    )
 
     msg = {
         "message": {

--- a/templates/admin_files.html
+++ b/templates/admin_files.html
@@ -21,6 +21,7 @@
         <input type="hidden" name="index" value="{{ loop.index0 }}">
         <input type="text" name="label" value="{{ f.label }}" placeholder="Nombre" class="border rounded p-1">
         <input type="text" name="name" value="{{ f.name }}" placeholder="Identificador" class="border rounded p-1">
+        <input type="text" name="storage_name" value="{{ f.storage_name }}" placeholder="Nombre final" class="border rounded p-1">
         <input type="text" name="description" value="{{ f.description }}" placeholder="Descripción" class="border rounded p-1 w-64">
         <label class="flex items-center space-x-1">
           <input type="checkbox" name="required" {% if f.required %}checked{% endif %}>
@@ -37,6 +38,7 @@
       <input type="hidden" name="category" value="{{ selected_cat }}">
       <input type="text" name="label" placeholder="Nombre" class="border rounded p-1">
       <input type="text" name="name" placeholder="Identificador" class="border rounded p-1">
+      <input type="text" name="storage_name" placeholder="Nombre final" class="border rounded p-1">
       <input type="text" name="description" placeholder="Descripción" class="border rounded p-1 w-64">
       <label class="flex items-center space-x-1">
         <input type="checkbox" name="required">

--- a/templates/emails/inscripcion.html
+++ b/templates/emails/inscripcion.html
@@ -1,0 +1,10 @@
+<p>Se ha recibido una inscripción para <strong>{{ categoria }}</strong>.</p>
+<p><strong>Nombre:</strong> {{ nombre }}</p>
+<ul>
+  {% for label, value in fields.items() %}
+    <li><strong>{{ label }}:</strong> {{ value }}</li>
+  {% endfor %}
+</ul>
+{% if folder_link %}
+<p>Carpeta en OneDrive: <a href="{{ folder_link }}">{{ folder_link }}</a></p>
+{% endif %}


### PR DESCRIPTION
## Summary
- allow each required file to define a custom storage name
- send notification emails using a Jinja2 template

## Testing
- `pytest`
- `flake8` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_689b879b87e08322b266f255b8e59ead