### PR TITLE
Improve UI and expose Graph configuration

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,10 +11,14 @@
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen flex flex-col">
   <nav class="bg-white dark:bg-gray-800 shadow mb-6">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <div class="space-x-4">
-        <a href="{% url 'index' %}" class="font-semibold hover:underline">Inicio</a>
+      <a href="{% url 'index' %}" class="text-lg font-semibold">INSCRIP</a>
+      <div class="flex items-center space-x-4">
+        <a href="{% url 'index' %}" class="hover:underline">Inicio</a>
+        {% if request.user.is_staff %}
+          <a href="{% url 'settings' %}" class="hover:underline">Configuración</a>
+        {% endif %}
+        <button id="toggleDark" class="px-2 py-1 border rounded" aria-label="Cambiar modo">Modo</button>
       </div>
-      <button id="toggleDark" class="px-2 py-1 border rounded">Modo</button>
     </div>
   </nav>
   <main class="container mx-auto px-4 flex-1">

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,12 +1,13 @@
 {% extends 'base.html' %}
 {% block title %}Formulario de {{ cat.name }}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">Formulario - {{ cat.name }}</h1>
-<form id="inscripcionForm" method="post" enctype="multipart/form-data" class="space-y-4">
+<h1 class="text-2xl font-bold mb-6 text-center">Formulario - {{ cat.name }}</h1>
+<form id="inscripcionForm" method="post" enctype="multipart/form-data" class="max-w-2xl mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow space-y-6">
   {% for field in fields %}
     <div>
       <label class="block mb-1">{{ field.label }}{% if field.required %} *{% endif %}</label>
-      <input type="{{ field.type }}" name="{{ field.name }}" {% if field.required %}required{% endif %} class="w-full border rounded p-2">
+      <input type="{{ field.type }}" name="{{ field.name }}" {% if field.required %}required{% endif %}
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
     </div>
   {% endfor %}
 
@@ -14,18 +15,22 @@
     <div>
       <label class="block mb-1">{{ f.label }}{% if f.required %} *{% endif %}</label>
       {% if f.description %}
-        <p class="text-sm text-gray-600">{{ f.description }}</p>
+        <p class="text-sm text-gray-600 dark:text-gray-400">{{ f.description }}</p>
       {% endif %}
-      <input type="file" name="{{ f.name }}" {% if f.required %}required{% endif %} class="w-full border rounded" accept="{{ upload_exts|join(',') }}">
+      <input type="file" name="{{ f.name }}" {% if f.required %}required{% endif %}
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+             accept="{{ upload_exts|join(',') }}">
     </div>
   {% endfor %}
 
-  <div id="filePreview" class="text-sm text-gray-500"></div>
-  <div class="w-full bg-gray-200 rounded h-2">
+  <div id="filePreview" class="text-sm text-gray-500 dark:text-gray-400"></div>
+  <div class="w-full bg-gray-200 dark:bg-gray-700 rounded h-2">
     <div id="progressBar" class="bg-blue-500 h-2 w-0"></div>
   </div>
 
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Enviar</button>
+  <div class="text-right">
+    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Enviar</button>
+  </div>
 </form>
 <script>
 const fileInputs = document.querySelectorAll('input[type="file"]');

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,14 @@
 {% extends 'base.html' %}
 {% block title %}{{ title }}{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">{{ title }}</h1>
-<p class="mb-4">Seleccione una categoría:</p>
-<div class="grid gap-4 md:grid-cols-2">
+<h1 class="text-2xl font-bold mb-6 text-center">{{ title }}</h1>
+<p class="mb-6 text-center">Seleccione una categoría:</p>
+<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
   {% for item in menu %}
-    <a href="{% url 'inscripcion' item.key %}" class="block p-4 bg-white dark:bg-gray-800 rounded shadow hover:bg-gray-50 dark:hover:bg-gray-700">{{ item.name }}</a>
+    <a href="{% url 'inscripcion' item.key %}"
+       class="block p-6 text-center bg-white dark:bg-gray-800 rounded shadow hover:shadow-md transition">
+       {{ item.name }}
+    </a>
   {% endfor %}
 </div>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -2,47 +2,57 @@
 {% block title %}Configuración{% endblock %}
 
 {% block content %}
-<h1 class="text-2xl mb-4">Configuración</h1>
-<form method="post" class="space-y-6">
+<h1 class="text-2xl font-bold mb-6 text-center">Configuración</h1>
+<form method="post" class="max-w-2xl mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow space-y-6">
   {% csrf_token %}
-  <div>
-    <h2 class="text-xl font-semibold mb-2">Correo</h2>
-    <div class="mb-2">
-      <label class="block">Usuario</label>
-      <input type="text" name="mail_user" value="{{ settings.mail.mail_user }}" class="border p-2 w-full" />
+  <div class="space-y-4">
+    <h2 class="text-xl font-semibold">Correo (SMTP)</h2>
+    <div>
+      <label class="block mb-1">Usuario</label>
+      <input type="text" name="mail_user" value="{{ settings.mail.mail_user }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
     </div>
-    <div class="mb-2">
-      <label class="block">Contraseña</label>
-      <input type="password" name="mail_password" value="{{ settings.mail.mail_password }}" class="border p-2 w-full" />
+    <div>
+      <label class="block mb-1">Contraseña</label>
+      <input type="password" name="mail_password" value="{{ settings.mail.mail_password }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
     </div>
-    <div class="mb-2">
-      <label class="block">Servidor SMTP</label>
-      <input type="text" name="smtp_host" value="{{ settings.mail.smtp_host }}" class="border p-2 w-full" />
+    <div>
+      <label class="block mb-1">Servidor SMTP</label>
+      <input type="text" name="smtp_host" value="{{ settings.mail.smtp_host }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
     </div>
-    <div class="mb-2">
-      <label class="block">Puerto SMTP</label>
-      <input type="number" name="smtp_port" value="{{ settings.mail.smtp_port }}" class="border p-2 w-full" />
-    </div>
-  </div>
-  <div>
-    <h2 class="text-xl font-semibold mb-2">OneDrive</h2>
-    <div class="mb-2">
-      <label class="block">Client ID</label>
-      <input type="text" name="client_id" value="{{ settings.onedrive.client_id }}" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Client Secret</label>
-      <input type="text" name="client_secret" value="{{ settings.onedrive.client_secret }}" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Tenant ID</label>
-      <input type="text" name="tenant_id" value="{{ settings.onedrive.tenant_id }}" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">User ID</label>
-      <input type="text" name="user_id" value="{{ settings.onedrive.user_id }}" class="border p-2 w-full" />
+    <div>
+      <label class="block mb-1">Puerto SMTP</label>
+      <input type="number" name="smtp_port" value="{{ settings.mail.smtp_port }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
     </div>
   </div>
-  <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">Guardar</button>
+  <div class="space-y-4">
+    <h2 class="text-xl font-semibold">Microsoft Graph</h2>
+    <div>
+      <label class="block mb-1">Client ID</label>
+      <input type="text" name="client_id" value="{{ settings.onedrive.client_id }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+    </div>
+    <div>
+      <label class="block mb-1">Client Secret</label>
+      <input type="text" name="client_secret" value="{{ settings.onedrive.client_secret }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+    </div>
+    <div>
+      <label class="block mb-1">Tenant ID</label>
+      <input type="text" name="tenant_id" value="{{ settings.onedrive.tenant_id }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+    </div>
+    <div>
+      <label class="block mb-1">User ID</label>
+      <input type="text" name="user_id" value="{{ settings.onedrive.user_id }}"
+             class="w-full border border-gray-300 dark:border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+    </div>
+  </div>
+  <div class="text-right">
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Guardar</button>
+  </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add config link in top navigation for staff
- refresh settings, forms and index with cleaner minimal styling

## Testing
- `python manage.py check` *(fails: No module named 'django')*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_689cb733f1a4832290aeef7daf4cc655